### PR TITLE
Fix typo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ResponseBody = binary() | pid() | undefined
 Reason = connection_closed | connect_timeout | timeout
 ``` 
 
-Possible `Options` for `request` function:
+Possible `Options` for `start` function:
 
 `{connect_timeout, Milliseconds}` specifies how many milliseconds the
 client can spend trying to establish a connection to the server. This


### PR DESCRIPTION
A typo here, that lead me to believe for a bit that there were options per request.