### PR TITLE
Change request path typespec to binary

### DIFF
--- a/include/fusco_types.hrl
+++ b/include/fusco_types.hrl
@@ -24,6 +24,8 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
+-type path() :: binary().
+
 -type header() :: binary().
 
 -type headers() :: [{header(), iodata()}].

--- a/src/fusco.erl
+++ b/src/fusco.erl
@@ -103,7 +103,7 @@ disconnect(Client) ->
 %% @doc Makes a request using a client already connected.
 %% @end
 %%------------------------------------------------------------------------------
--spec request(pid(), iodata(), method(), headers(), iodata(), pos_timeout()) ->
+-spec request(pid(), path(), method(), headers(), iodata(), pos_timeout()) ->
     result().
 request(Client, Path, Method, Hdrs, Body, Timeout) ->
     request(Client, Path, Method, Hdrs, Body, 1, Timeout).
@@ -135,7 +135,7 @@ request(Client, Path, Method, Hdrs, Body, Timeout) ->
 %% `Host' = `"example.com"'<br/>
 %% `Port' = `80'<br/>
 %% `Ssl' = `false'<br/>
-%% `Path' = `"/foobar"'<br/>
+%% `Path' = `<<"/foobar">>'<br/>
 %% `Path' must begin with a forward slash `/'.
 %%
 %% `Method' is either a string, stating the HTTP method exactly as in the
@@ -191,7 +191,7 @@ request(Client, Path, Method, Hdrs, Body, Timeout) ->
 %% list of all available options, please check OTP's ssl module manpage.
 %% @end
 %%------------------------------------------------------------------------------
--spec request(pid(), iodata(), method(), headers(), iodata(), integer(),
+-spec request(pid(), path(), method(), headers(), iodata(), integer(),
               pos_timeout()) -> result().
 request(Client, Path, Method, Hdrs, Body, SendRetry,
         Timeout) when is_binary(Path) ->

--- a/src/fusco_lib.erl
+++ b/src/fusco_lib.erl
@@ -74,7 +74,7 @@ parse_url(URL) ->
 %%------------------------------------------------------------------------------
 %% @spec (Path, Method, Headers, Host, Body, Cookies) ->
 %%    Request
-%% Path = iolist()
+%% Path = path()
 %% Method = atom() | string()
 %% Headers = [{atom() | string(), string()}]
 %% Host = string()
@@ -83,7 +83,7 @@ parse_url(URL) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec format_request(iolist(), method(), headers(), string(),  iolist(),
+-spec format_request(path(), method(), headers(), string(),  iolist(),
                      {boolean(), [fusco_cookie()]}) -> {iodata(), iodata()}.
 format_request(Path, Method, Hdrs, Host, Body, Cookies) ->
     {AllHdrs, ConHdr} =
@@ -339,7 +339,7 @@ split_port(Scheme, [P | T], Port) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec add_mandatory_hdrs(string(), headers(), host(),
+-spec add_mandatory_hdrs(path(), headers(), host(),
                          iolist(), {boolean(), [fusco_cookie()]}) ->
     {iodata(), iodata()}.
 add_mandatory_hdrs(_Path, Hdrs, Host, Body, {_, []}) ->


### PR DESCRIPTION
Previously the type of the path was `iodata()`, but all the fusco code assumed it was a `binary()`.